### PR TITLE
Require at least Ruby 2.4.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+ruby "~> 2.4.1"
+
 git_source(:github) do |repo_name|
   repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
   "https://github.com/#{repo_name}.git"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -279,5 +279,8 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
 
+RUBY VERSION
+   ruby 2.4.1p111
+
 BUNDLED WITH
    1.16.1


### PR DESCRIPTION
The app is throwing an error on Heroku because I used the `&.` version of try, which only works in Ruby 2.3+. Let's go ahead and require a newer Ruby so Heroku will deploy with it.